### PR TITLE
Make frontmatter regex lazy

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -5,7 +5,7 @@ export type ParseResult = {
   content: string;
 };
 
-const reFrontmatter = /^---([\s\S]*)^---$([\s\S]*)/m;
+const reFrontmatter = /^---([\s\S]*?)^---$([\s\S]*)/m;
 
 /**
  * Parses the front matter of the input string and returns the


### PR DESCRIPTION
I'm not sure if this has performance implications, but in my tests it should fix the issue in #1.