### PR TITLE
Add better types for ParseResult's data

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ where:
 
 ```ts
 type ParseResult = {
-  data: unknown;
+  data: undefined | Record<string, string>;
   content: string;
 };
 ```

--- a/mod.ts
+++ b/mod.ts
@@ -1,7 +1,7 @@
 import { yamlParse } from "./deps.ts";
 
 export type ParseResult = {
-  data: unknown;
+  data: undefined | Record<string, string>;
   content: string;
 };
 


### PR DESCRIPTION
I believe it can either be undefined or an object of strings.